### PR TITLE
Use mruby-onig-regexp gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -93,8 +93,11 @@ MRuby::GemBox.new do |conf|
   # WvD ADDITION: Use sleep module
   conf.gem :github => 'matsumotory/mruby-sleep'
   
+  # WvD ADDITION: Use the Onigmo regex module
+  conf.gem :mgem => 'mruby-onig-regexp'
+  
   # WvD ADDITION: Use marshal module
-  conf.gem :github => "WaveformDelta/mruby-marshal", :branch => "master"
+  conf.gem :mgem => 'mruby-marshal'
  
 end
 __EOF__
@@ -131,8 +134,11 @@ MRuby::Build.new do |conf|
   # WvD ADDITION: Use sleep module
   conf.gem :github => 'matsumotory/mruby-sleep'
   
+  # WvD ADDITION: use the Onigmo regex module
+  conf.gem :mgem => 'mruby-onig-regexp'
+
   # WvD ADDITION: Use marshal module
-  conf.gem :github => "WaveformDelta/mruby-marshal", :branch => "master"
+  conf.gem :mgem => 'mruby-marshal'
 end
 
 SIM_SYSROOT="#{SIMSDKPATH}"

--- a/Rakefile
+++ b/Rakefile
@@ -144,7 +144,7 @@ end
 SIM_SYSROOT="#{SIMSDKPATH}"
 DEVICE_SYSROOT="#{IOSSDKPATH}"
 
-MRuby::CrossBuild.new('ios-simulator') do |conf|
+MRuby::CrossBuild.new('i386-apple-darwin') do |conf|
   conf.bins = []
 
   conf.gembox 'custom'
@@ -152,22 +152,22 @@ MRuby::CrossBuild.new('ios-simulator') do |conf|
   conf.cc do |cc|
     cc.command = 'xcrun'
     cc.defines = %w(MRB_INTEGER_DIVISION)
-    cc.flags = %W(-sdk iphoneos clang -miphoneos-version-min=5.0 -arch i386 -isysroot \#{SIM_SYSROOT} -g -O3 -Wall -fexceptions -fembed-bitcode -Werror-implicit-function-declaration)
+    cc.flags = %W(-sdk iphoneos clang -miphoneos-version-min=8.0 -arch i386 -isysroot \#{SIM_SYSROOT} -g -O3 -Wall -fexceptions -fembed-bitcode -Werror-implicit-function-declaration)
   end
 
   conf.cxx do |cxx|
     cxx.command = 'xcrun'
     cxx.defines = %w(MRB_INTEGER_DIVISION)
-    cxx.flags = %W(-sdk iphoneos clang -x c++ -miphoneos-version-min=5.0 -arch i386 -isysroot \#{SIM_SYSROOT} -g -O3 -Wall -fembed-bitcode -Werror-implicit-function-declaration)
+    cxx.flags = %W(-sdk iphoneos clang -x c++ -miphoneos-version-min=8.0 -arch i386 -isysroot \#{SIM_SYSROOT} -g -O3 -Wall -fembed-bitcode -Werror-implicit-function-declaration)
   end
 
   conf.linker do |linker|
     linker.command = 'xcrun'
-    linker.flags = %W(-sdk iphoneos clang -x c++ -miphoneos-version-min=5.0 -arch i386 -isysroot \#{SIM_SYSROOT})
+    linker.flags = %W(-sdk iphoneos clang -x c++ -miphoneos-version-min=8.0 -arch i386 -isysroot \#{SIM_SYSROOT})
   end
 end
 
-MRuby::CrossBuild.new('ios-simulator-x86_64') do |conf|
+MRuby::CrossBuild.new('x86_64-apple-darwin') do |conf|
   conf.bins = []
 
   conf.gembox 'custom'
@@ -175,22 +175,22 @@ MRuby::CrossBuild.new('ios-simulator-x86_64') do |conf|
   conf.cc do |cc|
     cc.command = 'xcrun'
     cc.defines = %w(MRB_INTEGER_DIVISION)
-    cc.flags = %W(-sdk iphoneos clang -miphoneos-version-min=5.0 -arch x86_64 -isysroot \#{SIM_SYSROOT} -g -O3 -Wall -fexceptions -fembed-bitcode -Werror-implicit-function-declaration)
+    cc.flags = %W(-sdk iphoneos clang -miphoneos-version-min=8.0 -arch x86_64 -isysroot \#{SIM_SYSROOT} -g -O3 -Wall -fexceptions -fembed-bitcode -Werror-implicit-function-declaration)
   end
 
   conf.cxx do |cxx|
     cxx.command = 'xcrun'
     cxx.defines = %w(MRB_INTEGER_DIVISION)
-    cxx.flags = %W(-sdk iphoneos clang -x c++ -miphoneos-version-min=5.0 -arch x86_64 -isysroot \#{SIM_SYSROOT} -g -O3 -Wall -fembed-bitcode -Werror-implicit-function-declaration)
+    cxx.flags = %W(-sdk iphoneos clang -x c++ -miphoneos-version-min=8.0 -arch x86_64 -isysroot \#{SIM_SYSROOT} -g -O3 -Wall -fembed-bitcode -Werror-implicit-function-declaration)
   end
 
   conf.linker do |linker|
     linker.command = 'xcrun'
-    linker.flags = %W(-sdk iphoneos clang -x c++ -miphoneos-version-min=5.0 -arch x86_64 -isysroot \#{SIM_SYSROOT})
+    linker.flags = %W(-sdk iphoneos clang -x c++ -miphoneos-version-min=8.0 -arch x86_64 -isysroot \#{SIM_SYSROOT})
   end
 end
 
-MRuby::CrossBuild.new('ios-armv7') do |conf|
+MRuby::CrossBuild.new('armv7-apple-darwin') do |conf|
   conf.bins = []
 
   conf.gembox 'custom'
@@ -213,7 +213,7 @@ MRuby::CrossBuild.new('ios-armv7') do |conf|
   end
 end
 
-MRuby::CrossBuild.new('ios-armv7s') do |conf|
+MRuby::CrossBuild.new('armv7s-apple-darwin') do |conf|
   conf.bins = []
 
   conf.gembox 'custom'
@@ -236,7 +236,7 @@ MRuby::CrossBuild.new('ios-armv7s') do |conf|
   end
 end
 
-MRuby::CrossBuild.new('ios-arm64') do |conf|
+MRuby::CrossBuild.new('aarch64-apple-darwin') do |conf|
   conf.bins = []
 
   conf.gembox 'custom'
@@ -256,6 +256,29 @@ MRuby::CrossBuild.new('ios-arm64') do |conf|
   conf.linker do |linker|
     linker.command = 'xcrun'
     linker.flags = %W(-sdk iphoneos clang -x c++ -arch arm64 -isysroot \#{DEVICE_SYSROOT})
+  end
+end
+
+MRuby::CrossBuild.new('arm-apple-darwin') do |conf|
+  conf.bins = []
+
+  conf.gembox 'custom'
+
+  conf.cc do |cc|
+    cc.command = 'xcrun'
+    cc.defines = %w(MRB_INTEGER_DIVISION)
+    cc.flags = %W(-sdk iphoneos clang -arch arm64e -isysroot \#{DEVICE_SYSROOT} -g -O3 -Wall -fexceptions -fembed-bitcode -Werror-implicit-function-declaration)
+  end
+
+  conf.cxx do |cxx|
+    cxx.command = 'xcrun'
+    cxx.defines = %w(MRB_INTEGER_DIVISION)
+    cxx.flags = %W(-sdk iphoneos clang -x c++ -arch arm64e -isysroot \#{DEVICE_SYSROOT} -g -O3 -Wall -fembed-bitcode -Werror-implicit-function-declaration)
+  end
+
+  conf.linker do |linker|
+    linker.command = 'xcrun'
+    linker.flags = %W(-sdk iphoneos clang -x c++ -arch arm64e -isysroot \#{DEVICE_SYSROOT})
   end
 end
 __EOF__
@@ -303,7 +326,13 @@ file "bin/mruby" => [:build_mruby, "bin"] do
 end
 
 file "MRuby.framework/Versions/Current/MRuby" => [:build_mruby, "MRuby.framework/Versions/1.0.0/"] do
-  sh "#{XCODEROOT}/Toolchains/XcodeDefault.xctoolchain/usr/bin/lipo -arch i386 mruby/build/ios-simulator/lib/libmruby.a -arch x86_64 mruby/build/ios-simulator-x86_64/lib/libmruby.a -arch arm64 mruby/build/ios-arm64/lib/libmruby.a -arch armv7 mruby/build/ios-armv7/lib/libmruby.a -arch armv7s mruby/build/ios-armv7s/lib/libmruby.a -create -output MRuby.framework/Versions/Current/MRuby"
+  sh "#{XCODEROOT}/Toolchains/XcodeDefault.xctoolchain/usr/bin/lipo -arch i386 mruby/build/i386-apple-darwin/lib/libmruby.a"\
+  " -arch x86_64 mruby/build/x86_64-apple-darwin/lib/libmruby.a"\
+  " -arch arm64e mruby/build/arm-apple-darwin/lib/libmruby.a"\
+  " -arch arm64 mruby/build/aarch64-apple-darwin/lib/libmruby.a"\
+  " -arch armv7 mruby/build/armv7-apple-darwin/lib/libmruby.a"\
+  " -arch armv7s mruby/build/armv7s-apple-darwin/lib/libmruby.a"\
+  " -create -output MRuby.framework/Versions/Current/MRuby"
 end
 
 task :mruby_headers => [:build_mruby, "MRuby.framework/Versions/1.0.0/Headers"] do

--- a/Rakefile
+++ b/Rakefile
@@ -144,29 +144,6 @@ end
 SIM_SYSROOT="#{SIMSDKPATH}"
 DEVICE_SYSROOT="#{IOSSDKPATH}"
 
-MRuby::CrossBuild.new('i386-apple-darwin') do |conf|
-  conf.bins = []
-
-  conf.gembox 'custom'
-
-  conf.cc do |cc|
-    cc.command = 'xcrun'
-    cc.defines = %w(MRB_INTEGER_DIVISION)
-    cc.flags = %W(-sdk iphoneos clang -miphoneos-version-min=8.0 -arch i386 -isysroot \#{SIM_SYSROOT} -g -O3 -Wall -fexceptions -fembed-bitcode -Werror-implicit-function-declaration)
-  end
-
-  conf.cxx do |cxx|
-    cxx.command = 'xcrun'
-    cxx.defines = %w(MRB_INTEGER_DIVISION)
-    cxx.flags = %W(-sdk iphoneos clang -x c++ -miphoneos-version-min=8.0 -arch i386 -isysroot \#{SIM_SYSROOT} -g -O3 -Wall -fembed-bitcode -Werror-implicit-function-declaration)
-  end
-
-  conf.linker do |linker|
-    linker.command = 'xcrun'
-    linker.flags = %W(-sdk iphoneos clang -x c++ -miphoneos-version-min=8.0 -arch i386 -isysroot \#{SIM_SYSROOT})
-  end
-end
-
 MRuby::CrossBuild.new('x86_64-apple-darwin') do |conf|
   conf.bins = []
 
@@ -175,64 +152,18 @@ MRuby::CrossBuild.new('x86_64-apple-darwin') do |conf|
   conf.cc do |cc|
     cc.command = 'xcrun'
     cc.defines = %w(MRB_INTEGER_DIVISION)
-    cc.flags = %W(-sdk iphoneos clang -miphoneos-version-min=8.0 -arch x86_64 -isysroot \#{SIM_SYSROOT} -g -O3 -Wall -fexceptions -fembed-bitcode -Werror-implicit-function-declaration)
+    cc.flags = %W(-sdk iphoneos clang -miphoneos-version-min=11.0 -arch x86_64 -isysroot \#{SIM_SYSROOT} -g -O3 -Wall -fexceptions -fembed-bitcode -Werror-implicit-function-declaration)
   end
 
   conf.cxx do |cxx|
     cxx.command = 'xcrun'
     cxx.defines = %w(MRB_INTEGER_DIVISION)
-    cxx.flags = %W(-sdk iphoneos clang -x c++ -miphoneos-version-min=8.0 -arch x86_64 -isysroot \#{SIM_SYSROOT} -g -O3 -Wall -fembed-bitcode -Werror-implicit-function-declaration)
+    cxx.flags = %W(-sdk iphoneos clang -x c++ -miphoneos-version-min=11.0 -arch x86_64 -isysroot \#{SIM_SYSROOT} -g -O3 -Wall -fembed-bitcode -Werror-implicit-function-declaration)
   end
 
   conf.linker do |linker|
     linker.command = 'xcrun'
-    linker.flags = %W(-sdk iphoneos clang -x c++ -miphoneos-version-min=8.0 -arch x86_64 -isysroot \#{SIM_SYSROOT})
-  end
-end
-
-MRuby::CrossBuild.new('armv7-apple-darwin') do |conf|
-  conf.bins = []
-
-  conf.gembox 'custom'
-
-  conf.cc do |cc|
-    cc.command = 'xcrun'
-    cc.defines = %w(MRB_INTEGER_DIVISION)
-    cc.flags = %W(-sdk iphoneos clang -arch armv7 -isysroot \#{DEVICE_SYSROOT} -g -O3 -Wall -fexceptions -fembed-bitcode -Werror-implicit-function-declaration)
-  end
-
-  conf.cxx do |cxx|
-    cxx.command = 'xcrun'
-    cxx.defines = %w(MRB_INTEGER_DIVISION)
-    cxx.flags = %W(-sdk iphoneos clang -x c++ -arch armv7 -isysroot \#{DEVICE_SYSROOT} -g -O3 -Wall -fembed-bitcode -Werror-implicit-function-declaration)
-  end
-
-  conf.linker do |linker|
-    linker.command = 'xcrun'
-    linker.flags = %W(-sdk iphoneos clang -x c++ -arch armv7 -isysroot \#{DEVICE_SYSROOT})
-  end
-end
-
-MRuby::CrossBuild.new('armv7s-apple-darwin') do |conf|
-  conf.bins = []
-
-  conf.gembox 'custom'
-
-  conf.cc do |cc|
-    cc.command = 'xcrun'
-    cc.defines = %w(MRB_INTEGER_DIVISION)
-    cc.flags = %W(-sdk iphoneos clang -arch armv7s -isysroot \#{DEVICE_SYSROOT} -g -O3 -Wall -fexceptions -fembed-bitcode -Werror-implicit-function-declaration)
-  end
-
-  conf.cxx do |cxx|
-    cxx.command = 'xcrun'
-    cxx.defines = %w(MRB_INTEGER_DIVISION)
-    cxx.flags = %W(-sdk iphoneos clang -x c++ -arch armv7s -isysroot \#{DEVICE_SYSROOT} -g -O3 -Wall -fembed-bitcode -Werror-implicit-function-declaration)
-  end
-
-  conf.linker do |linker|
-    linker.command = 'xcrun'
-    linker.flags = %W(-sdk iphoneos clang -x c++ -arch armv7s -isysroot \#{DEVICE_SYSROOT})
+    linker.flags = %W(-sdk iphoneos clang -x c++ -miphoneos-version-min=11.0 -arch x86_64 -isysroot \#{SIM_SYSROOT})
   end
 end
 
@@ -326,12 +257,10 @@ file "bin/mruby" => [:build_mruby, "bin"] do
 end
 
 file "MRuby.framework/Versions/Current/MRuby" => [:build_mruby, "MRuby.framework/Versions/1.0.0/"] do
-  sh "#{XCODEROOT}/Toolchains/XcodeDefault.xctoolchain/usr/bin/lipo -arch i386 mruby/build/i386-apple-darwin/lib/libmruby.a"\
+  sh "#{XCODEROOT}/Toolchains/XcodeDefault.xctoolchain/usr/bin/lipo"\
   " -arch x86_64 mruby/build/x86_64-apple-darwin/lib/libmruby.a"\
   " -arch arm64e mruby/build/arm-apple-darwin/lib/libmruby.a"\
   " -arch arm64 mruby/build/aarch64-apple-darwin/lib/libmruby.a"\
-  " -arch armv7 mruby/build/armv7-apple-darwin/lib/libmruby.a"\
-  " -arch armv7s mruby/build/armv7s-apple-darwin/lib/libmruby.a"\
   " -create -output MRuby.framework/Versions/Current/MRuby"
 end
 


### PR DESCRIPTION
We need the ``mruby-onig-regexp`` gem for complete regular expression support. This modifies the build to include that gem by default.

It also updates the build to include arm64e support, and drops support for 32-bit devices.
